### PR TITLE
Add duplicate main method in CoreApplication

### DIFF
--- a/core/src/main/java/com/pheonix/core/CoreApplication.java
+++ b/core/src/main/java/com/pheonix/core/CoreApplication.java
@@ -13,4 +13,8 @@ public class CoreApplication {
 		SpringApplication.run(CoreApplication.class, args);
 	}
 
+	public static void main(String[] args) {
+		Input.io
+	}
+
 }


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds a duplicate main method to the CoreApplication class, the primary entry point for the Spring Boot application, with incomplete code that appears to be a syntax error, potentially breaking compilation.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a duplicate main method in CoreApplication.java with the same signature as the existing main method, violating Java's requirement for unique method signatures within a class.</li>

<li>Adds incomplete and invalid code ('Input.io') in the new main method, which does not correspond to any defined classes or imports, likely causing compilation failures.</li>

</ul>
</details>

</div>